### PR TITLE
Update README links for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ Please use the black formatter to format the code.
 
 ## Attributions
 
-- Heavily inspired by [posting](https://github.com/darrenburns/posting)
-- Bagels is built with [textual](https://https://textual.textualize.io/)
+- Heavily inspired by [posting](https://posting.sh/)
+- Bagels is built with [textual](https://textual.textualize.io/)
 - It's called bagels because I like bagels


### PR DESCRIPTION
Hi! Love the app!

This PR just updates the attribution links in the README file:

- Fix broken Textual URL (remove extra `https`)
- Change Posting URL from Repo to website (just to be consistent with Textual's link pointing to their website too)