### PR TITLE
docs: remove unnecessary uv sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ uv tool upgrade bagels
 ```sh
 git clone https://github.com/EnhancedJax/Bagels.git
 cd Bagels
-uv sync
 uv run pre-commit install
 mkdir instance
 uv run bagels --at "./instance/" # runs app with storage in ./instance/


### PR DESCRIPTION
`uv run` now sync automatically no need to manually call `uv sync`.
I tested it works by following the instructions without `uv sync`.