### PR TITLE
Include names of items in delete messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.5
+## 0.3.6
 
 - Added ActualBudget migration
 - Fixed datemode styling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bagels"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
     { name = "Jax", email = "enhancedjax@gmail.com" }
 ]

--- a/src/bagels/components/modules/accountmode.py
+++ b/src/bagels/components/modules/accountmode.py
@@ -188,6 +188,7 @@ class AccountMode(ScrollableContainer):
 
     def action_delete(self) -> None:
         id = self.page_parent.mode["accountId"]["default_value"]
+        name = self.page_parent.mode["accountId"]["default_value_text"]
 
         def check_delete(result) -> None:
             if result:
@@ -202,7 +203,9 @@ class AccountMode(ScrollableContainer):
 
         if id:
             self.app.push_screen(
-                ConfirmationModal("Are you sure you want to archive this account?"),
+                ConfirmationModal(
+                    f"Are you sure you want to archive account '{name}'?"
+                ),
                 check_delete,
             )
         else:

--- a/src/bagels/components/modules/categories.py
+++ b/src/bagels/components/modules/categories.py
@@ -164,8 +164,12 @@ class Categories(Static):
                     )
                 self.rebuild()
 
+        category = get_category_by_id(self.current_row)
+
         self.app.push_screen(
-            ConfirmationModal("Are you sure you want to delete this record?"),
+            ConfirmationModal(
+                f"Are you sure you want to delete category '[{category.color}]●[/{category.color}] {category.name}'?"
+            ),
             check_delete,
         )
 

--- a/src/bagels/components/modules/people.py
+++ b/src/bagels/components/modules/people.py
@@ -8,6 +8,7 @@ from bagels.config import CONFIG
 from bagels.forms.person_forms import PersonForm
 from bagels.managers.persons import (
     delete_person,
+    get_person_by_id,
     get_persons_with_net_due,
     update_person,
 )
@@ -89,9 +90,11 @@ class People(Static):
                     )
                 self.rebuild()
 
+        person = get_person_by_id(self.current_row)
+
         self.app.push_screen(
             ConfirmationModal(
-                "Are you sure you want to delete this person? Existing records with this person will not be affected."
+                f"Are you sure you want to delete person '{person.name}'? Existing records with this person will not be affected."
             ),
             check_delete,
         )

--- a/src/bagels/components/modules/templates.py
+++ b/src/bagels/components/modules/templates.py
@@ -236,9 +236,13 @@ class Templates(Static):
                 self.selected_template_id = None
                 self.rebuild()
 
+        template = get_template_by_id(self.selected_template_id)
+
         # ----------------- - ---------------- #
         self.app.push_screen(
-            ConfirmationModal("Are you sure you want to delete this template?"),
+            ConfirmationModal(
+                f"Are you sure you want to delete template '{template.label}'?"
+            ),
             check_delete,
         )
 


### PR DESCRIPTION
hello! Loving the project.

I found when deleting items (especially from a crowded list like categories) I was unsure if I'd correctly selected the item I wanted to delete after pressing the delete button.

Here, it's not clear which item is about to be deleted.

<img width="798" alt="image" src="https://github.com/user-attachments/assets/460c106f-d45c-4f4a-a8cf-3a92610bc26b" />


---

This updates the delete confirmation messages to include the name of the item you're about to delete.

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/39f5b9e1-e539-4f8b-824e-a758abc38018" />
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/fc74cb72-51d1-4ecb-9cc3-1e8a348ced97" />
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/4150fe0d-0253-4c6d-8a63-7c8a6674c3d7" />
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/e2e52e85-fbb3-4626-bdf5-64fffa17c7a6" />
