### PR TITLE
fix: show current category color if top level

### DIFF
--- a/src/bagels/components/fields.py
+++ b/src/bagels/components/fields.py
@@ -87,7 +87,7 @@ class Field(Static):
         if not category:
             return
         self.autocomplete_postfix_display_label.update(
-            f"[{category.parentCategory.color if category.parentCategory else category.color}]{postfix_display}[/]"
+            f"[{(category.parentCategory or category).color}]{postfix_display}[/]"
         )
 
     def on_auto_complete_selected(self, event: AutoComplete.Selected) -> None:

--- a/src/bagels/components/fields.py
+++ b/src/bagels/components/fields.py
@@ -87,7 +87,7 @@ class Field(Static):
         if not category:
             return
         self.autocomplete_postfix_display_label.update(
-            f"[{category.parentCategory.color}]{postfix_display}[/]"
+            f"[{category.parentCategory.color if category.parentCategory else category.color}]{postfix_display}[/]"
         )
 
     def on_auto_complete_selected(self, event: AutoComplete.Selected) -> None:


### PR DESCRIPTION
71aef3f broke adding transactions with top-level categories (like Food/Transport). This fixes by using the current category's label if no parent exists. I'm not sure if you don't want people categorizing transactions with top-level categories, because it does let me auto-complete to them.